### PR TITLE
Fix missing separators between cells in VALUES data rows

### DIFF
--- a/engines/generator-sparql-1-1/test/extraCoverage.test.ts
+++ b/engines/generator-sparql-1-1/test/extraCoverage.test.ts
@@ -1,3 +1,4 @@
+import { traqulaIndentation } from '@traqula/core';
 import { Parser } from '@traqula/parser-sparql-1-1';
 import { AstFactory, completeGeneratorContext } from '@traqula/rules-sparql-1-1';
 import { beforeEach, describe, it } from 'vitest';
@@ -128,6 +129,26 @@ describe('extra generator coverage', () => {
       const lit = F.termLiteral(F.gen(), '42', typeIri);
       const result = rawGenerator.rdfLiteral(lit, context);
       expect(result).toBe(' 42 ');
+    });
+  });
+
+  describe('inlineData gImpl cell separators', () => {
+    const autoGen = (query: string): string => generator.generate(
+      F.forcedAutoGenTree(parser.parse(query)),
+      { [traqulaIndentation]: -1, indentInc: 0 },
+    );
+
+    it('separates adjacent prefixed names in a multi-variable row', ({ expect }) => {
+      const out = autoGen(`PREFIX ex: <http://example.org/>
+SELECT * WHERE { VALUES (?s ?p ?o) { (ex:a ex:b ex:c) } ?s ?p ?o }`);
+      expect(out).toContain('( ex:a ex:b ex:c )');
+      expect(() => parser.parse(out)).not.toThrow();
+    });
+
+    it('round-trips a single-variable VALUES block of prefixed names', ({ expect }) => {
+      const out = autoGen(`PREFIX ex: <http://example.org/>
+SELECT * WHERE { VALUES ?x { ex:a ex:b ex:c } ?x ?x ?x }`);
+      expect(() => parser.parse(out)).not.toThrow();
     });
   });
 });

--- a/packages/rules-sparql-1-1/lib/grammar/whereClause.ts
+++ b/packages/rules-sparql-1-1/lib/grammar/whereClause.ts
@@ -313,6 +313,7 @@ export const inlineData: SparqlRule<'inlineData', PatternValues> = <const> {
           F.printFilter(ast, () => PRINT_WORD('UNDEF'));
         } else {
           SUBRULE(graphNodePath, mapping[var_]);
+          F.printFilter(ast, () => PRINT_WORD(''));
         }
       }
       F.printFilter(ast, () => {

--- a/packages/test-utils/statics/algebra/canonical-sparql/base/sparql-1.1/values/values-many-once.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/base/sparql-1.1/values/values-many-once.sparql
@@ -1,5 +1,5 @@
 SELECT ?y ?z WHERE {
   VALUES( ?y ?z ){
-    ( <http://example.com/ns#a><http://example.com/ns#b> )
+    ( <http://example.com/ns#a> <http://example.com/ns#b> )
   }
 }

--- a/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/sparql-1.1/values/values-many-once.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/sparql-1.1/values/values-many-once.sparql
@@ -1,5 +1,5 @@
 SELECT ?y ?z WHERE {
   VALUES( ?y ?z ){
-    ( <http://example.com/ns#a><http://example.com/ns#b> )
+    ( <http://example.com/ns#a> <http://example.com/ns#b> )
   }
 }


### PR DESCRIPTION
Problem -

When the generator prints a multi-variable VALUES row, cells were concatenated without any whitespace separator. For prefixed names, adjacent tokens fuse into a single PNAME_LN at the lexer level, causing the generated query to fail round-trip parsing.

For example, `ex:a ex:b ex:c` would be emitted as `ex:aex:bex:c`, which re-parses as a single value instead of three, and throws a variable-count mismatch error.

Fix -

After each materialized cell, emit a trailing separator via F.printFilter(ast, () => PRINT_WORD('')) so that the next token — whether another cell or the closing ) — is always whitespace-separated.

Testing -

Added a round-trip test covering multi-variable VALUES rows with prefixed names and IRIs to confirm generated output parses back correctly.

Fixes #133.