### PR TITLE
Refine (narrow) algebraUtils.inScopeVariables results

### DIFF
--- a/engines/algebra-sparql-1-1/test/extraCoverage.test.ts
+++ b/engines/algebra-sparql-1-1/test/extraCoverage.test.ts
@@ -138,6 +138,52 @@ GROUP BY ( ?y AS ?x )`);
     });
   });
 
+  /**
+   * https://www.w3.org/TR/sparql12-query/#variableScope
+   * > Not visible: only in filter, exists/not exists, masked by a subselect,
+   * > non-projected GROUP variables, only in the right hand side of MINUS
+   */
+  describe('algebraUtils.inScopeVariables hides variables that cannot be in a solution mapping', () => {
+    function scopeOfWhere(query: string, quads = false): string[] {
+      const algebra = <Algebra.Project> toAlgebra(parser.parse(query), { quads });
+      return algebraUtils.inScopeVariables(algebra.input).map(v => v.value).sort();
+    }
+
+    it('does not descend into the pattern of an EXISTS', ({ expect }) => {
+      expect(scopeOfWhere('SELECT * WHERE { ?s ?p ?o FILTER EXISTS { ?hidden <http://a> <http://b> } }'))
+        .toEqual([ 'o', 'p', 's' ]);
+    });
+
+    it('does not descend into the pattern of a NOT EXISTS', ({ expect }) => {
+      expect(scopeOfWhere('SELECT * WHERE { ?s ?p ?o FILTER NOT EXISTS { ?hidden <http://a> <http://b> } }'))
+        .toEqual([ 'o', 'p', 's' ]);
+    });
+
+    it('does not descend into an EXISTS used outside of a FILTER', ({ expect }) => {
+      expect(scopeOfWhere('SELECT * WHERE { ?s ?p ?o BIND(EXISTS { ?hidden <http://a> <http://b> } AS ?b) }'))
+        .toEqual([ 'b', 'o', 'p', 's' ]);
+    });
+
+    it('only exposes the keys and aggregates of a GROUP', ({ expect }) => {
+      // The aggregate is bound to ?var0 by the group, ?c is bound by the extend above it.
+      expect(scopeOfWhere('SELECT ?s (COUNT(?o) AS ?c) WHERE { ?s ?p ?o } GROUP BY ?s'))
+        .toEqual([ 'c', 's', 'var0' ]);
+    });
+
+    it('does not expose the variables of a CONSTRUCT template', ({ expect }) => {
+      const algebra = toAlgebra(parser.parse('CONSTRUCT { ?s <http://a> ?hidden } WHERE { ?s ?p ?o }'));
+      expect(algebraUtils.inScopeVariables(algebra).map(v => v.value).sort()).toEqual([ 'o', 'p', 's' ]);
+    });
+
+    it('does not expose the variables of a DELETE template', ({ expect }) => {
+      const algebra = toAlgebra(
+        parser.parse('DELETE { ?s <http://a> ?hidden } WHERE { ?s ?p ?o }'),
+        { quads: true },
+      );
+      expect(algebraUtils.inScopeVariables(algebra).map(v => v.value).sort()).toEqual([ 'o', 'p', 's' ]);
+    });
+  });
+
   describe('createAlgebraContext with prefixes', () => {
     it('passes prefixes to the algebra context', ({ expect }) => {
       const ast = parser.parse('PREFIX ex: <http://example.org/> SELECT * WHERE { ex:s ex:p ex:o }');

--- a/engines/algebra-sparql-1-1/test/extraCoverage.test.ts
+++ b/engines/algebra-sparql-1-1/test/extraCoverage.test.ts
@@ -166,6 +166,8 @@ GROUP BY ( ?y AS ?x )`);
 
     it('only exposes the keys and aggregates of a GROUP', ({ expect }) => {
       // The aggregate is bound to ?var0 by the group, ?c is bound by the extend above it.
+      // var0 is out of scope for the project (since it cannot be targetted to be projected,
+      // but is in scope before the select.
       expect(scopeOfWhere('SELECT ?s (COUNT(?o) AS ?c) WHERE { ?s ?p ?o } GROUP BY ?s'))
         .toEqual([ 'c', 's', 'var0' ]);
     });

--- a/engines/algebra-sparql-1-1/test/recurse.test.ts
+++ b/engines/algebra-sparql-1-1/test/recurse.test.ts
@@ -11,19 +11,17 @@ import { suites } from './algebra.test.js';
 describe('util functions', () => {
   const factory = new AlgebraFactory();
 
-  /**
-   * `SELECT *` - which is what an empty projection is generated as - is only permitted
-   * when the query does not use grouping (https://www.w3.org/TR/sparql12-query/#modProjection).
-   * The round trip below therefore says nothing about grouped queries.
-   */
   function usesGrouping(op: Algebra.Operation): boolean {
     let grouping = false;
     algebraUtils.visitOperation(op, {
       // Variables of a nested projection are masked, its grouping is of no concern here.
       project: { preVisitor: () => ({ continue: false }) },
-      group: { visitor: () => {
-        grouping = true;
-      } },
+      group: {
+        preVisitor: () => ({ shortcut: true }),
+        visitor: () => {
+          grouping = true;
+        },
+      },
     });
     return grouping;
   }
@@ -37,6 +35,7 @@ describe('util functions', () => {
           if (clone.type === 'project' && !usesGrouping(clone.input)) {
             const scope = algebraUtils.inScopeVariables(clone.input);
             // Console.log(scope);
+            // Cannot perform `select *` on aggergates.
             const project = <Algebra.Project> toAlgebra(toAst(factory.createProject(clone.input, [])));
             for (const v of project.variables.map(v => v.value)) {
               expect(scope.map(v => v.value)).toContain(v);

--- a/engines/algebra-sparql-1-1/test/recurse.test.ts
+++ b/engines/algebra-sparql-1-1/test/recurse.test.ts
@@ -11,13 +11,30 @@ import { suites } from './algebra.test.js';
 describe('util functions', () => {
   const factory = new AlgebraFactory();
 
+  /**
+   * `SELECT *` - which is what an empty projection is generated as - is only permitted
+   * when the query does not use grouping (https://www.w3.org/TR/sparql12-query/#modProjection).
+   * The round trip below therefore says nothing about grouped queries.
+   */
+  function usesGrouping(op: Algebra.Operation): boolean {
+    let grouping = false;
+    algebraUtils.visitOperation(op, {
+      // Variables of a nested projection are masked, its grouping is of no concern here.
+      project: { preVisitor: () => ({ continue: false }) },
+      group: { visitor: () => {
+        grouping = true;
+      } },
+    });
+    return grouping;
+  }
+
   for (const suite of suites) {
     describe(suite, () => {
       for (const test of sparqlAlgebraTests(suite, false, true)) {
         const { name, json: expected } = test;
         it (name, ({ expect }) => {
           const clone = <Algebra.Operation> algebraUtils.mapOperation(<Algebra.Operation>expected, {});
-          if (clone.type === 'project') {
+          if (clone.type === 'project' && !usesGrouping(clone.input)) {
             const scope = algebraUtils.inScopeVariables(clone.input);
             // Console.log(scope);
             const project = <Algebra.Project> toAlgebra(toAst(factory.createProject(clone.input, [])));

--- a/packages/algebra-transformations-1-1/lib/algebraFactory.ts
+++ b/packages/algebra-transformations-1-1/lib/algebraFactory.ts
@@ -169,6 +169,9 @@ export class AlgebraFactory {
     return pattern;
   }
 
+  /**
+   * Providing no variables is interpreted as a `SELECT *`.
+   */
   public createProject(input: A.BaseOperation, variables: RDF.Variable[]): A.Project {
     return { type: A.Types.PROJECT, input: known(input), variables };
   }

--- a/packages/algebra-transformations-1-1/lib/util.ts
+++ b/packages/algebra-transformations-1-1/lib/util.ts
@@ -361,8 +361,8 @@ export function inScopeVariables(
         preVisitor: (op: A.Expression) =>
           op.subType === ExpressionTypes.EXISTENCE ? { continue: false } : {},
         visitor: (op: A.Expression & { variable?: RDF.Variable }) => {
-          if (op.subType === ExpressionTypes.AGGREGATE && (op).variable) {
-            addVariable((op).variable);
+          if (op.subType === ExpressionTypes.AGGREGATE && op.variable) {
+            addVariable(op.variable);
           }
         },
       },

--- a/packages/algebra-transformations-1-1/lib/util.ts
+++ b/packages/algebra-transformations-1-1/lib/util.ts
@@ -289,9 +289,17 @@ export function objectify(algebra: any): any {
 }
 
 /**
- * Detects all in-scope variables.
+ * Detects all [in-scope variables](https://www.w3.org/TR/sparql12-query/#variableScope).
  * In practice this means iterating through the entire algebra tree, finding all variables,
- * and stopping when a project function is found.
+ * and stopping at every operation that hides the variables of its input:
+ * - PROJECT only exposes the variables it projects.
+ * - GROUP only exposes its keys and the variables its aggregates are bound to.
+ * - The right-hand side of a MINUS is not in scope, only the left-hand side is.
+ * - The pattern of an `(NOT) EXISTS` is not in scope
+ *   ("use of a variable in FILTER or in MINUS does not cause the variable to be in-scope
+ *   outside of those forms").
+ * - The templates of a CONSTRUCT or a DELETE/INSERT consume solution mappings,
+ *   they do not produce them, so their variables are not in scope either.
  * @param {Operation} op - Input algebra tree.
  * @param visitor the visitor to be used to traverse the various nodes.
  * Allows you to provide a visitor with different default preVisitor cotexts.
@@ -339,11 +347,25 @@ export function inScopeVariables(
   function visitingRecursion(curOp: A.BaseOperation): void {
     // https://www.w3.org/TR/sparql11-query/#variableScope
     visitor(curOp, {
-      [Types.EXPRESSION]: { visitor: (op: A.Expression & { variable?: RDF.Variable }) => {
-        if (op.subType === ExpressionTypes.AGGREGATE && (op).variable) {
-          addVariable((op).variable);
-        }
-      } },
+      [Types.CONSTRUCT]: {
+        // The variables of the template are consumed, they are not in scope.
+        preVisitor: () => ({ ignoreKeys: new Set([ 'template' ]) }),
+      },
+      [Types.DELETE_INSERT]: {
+        // The variables of the templates are consumed, they are not in scope.
+        preVisitor: () => ({ ignoreKeys: new Set([ 'delete', 'insert' ]) }),
+      },
+      [Types.EXPRESSION]: {
+        // Variables only used within an expression are not in scope,
+        // this includes the pattern of an (NOT) EXISTS.
+        preVisitor: (op: A.Expression) =>
+          op.subType === ExpressionTypes.EXISTENCE ? { continue: false } : {},
+        visitor: (op: A.Expression & { variable?: RDF.Variable }) => {
+          if (op.subType === ExpressionTypes.AGGREGATE && (op).variable) {
+            addVariable((op).variable);
+          }
+        },
+      },
       [Types.EXTEND]: { visitor: op =>
         addVariable(op.variable),
       },
@@ -352,11 +374,16 @@ export function inScopeVariables(
           addVariable(op.name);
         }
       } },
-      [Types.GROUP]: { visitor: (op) => {
-        for (const v of op.variables) {
-          addVariable(v);
-        }
-      } },
+      [Types.GROUP]: {
+        // A group only outputs its keys and the variables its aggregates are bound to,
+        // the variables of its input are not visible above it.
+        preVisitor: () => ({ ignoreKeys: new Set([ 'variables', 'input' ]) }),
+        visitor: (op) => {
+          for (const v of op.variables) {
+            addVariable(v);
+          }
+        },
+      },
       [Types.PATH]: { visitor: (op) => {
         // Subject
         if (op.subject.termType === 'Variable') {


### PR DESCRIPTION
Existence filters, etc., wrongly caused the inScopeVariables function to say that variables were in scope.