### PR TITLE
Use docs/index.md as the documentation landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,3 +63,7 @@ When migrating from [SPARQL.JS](https://github.com/RubenVerborgh/SPARQL.js/) or 
 - [Design decisions](./design.md)
 - [Transformation catalogue](./transformation-catalogue.md)
 - [API documentation (TypeDoc)](https://comunica.github.io/traqula/)
+
+---
+
+{@include ../README.md}

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,7 +4,8 @@
   "theme": "default",
   "entryPointStrategy": "packages",
   "entryPoints": ["engines/*", "packages/*"],
-  "projectDocuments": ["docs/**/*.md"],
+  "readme": "docs/index.md",
+  "projectDocuments": ["docs/**/!(index).md"],
   "plugin": ["./typedoc.plugin.mjs"],
   "repositoryLinkTemplate": "https://github.com/comunica/traqula/{kind}/main/{path}"
 }


### PR DESCRIPTION
TypeDoc picked up the root README as the site's index page. The landing page now renders docs/index.md instead, and includes the README at the end so its monorepo overview stays on the site while README.md remains the repository and npm front page.

docs/index.md is excluded from projectDocuments to avoid generating a second, identical page for it.