### PR TITLE
Fix `LIMIT 0` not being transformed to algebra

### DIFF
--- a/engines/algebra-sparql-1-1/test/generateJson.test.ts
+++ b/engines/algebra-sparql-1-1/test/generateJson.test.ts
@@ -8,7 +8,6 @@ import { sparqlQueries, getStaticFilePath } from '@traqula/test-utils';
 import { describe, it } from 'vitest';
 import { toAlgebra, toAst } from '../lib/index.js';
 import { suites } from './algebra.test.js';
-import { allBaseTokens } from '../../../packages/rules-sparql-1-1/lib/lexer/lexer.js';
 
 // WARNING: use this script with caution!
 // After running this script, manual inspection of the output is needed to make sure that conversion happened correctly.

--- a/engines/algebra-sparql-1-1/test/generateJson.test.ts
+++ b/engines/algebra-sparql-1-1/test/generateJson.test.ts
@@ -54,7 +54,7 @@ describe.skip('algebra test generate', () => {
 
               writeFileSync(
                 join(blankToVariable ? rootJsonBlankToVariable : rootJson, algebraFileName),
-                JSON.stringify(algebra, null, 2),
+                `${JSON.stringify(algebra, null, 2)}\n`,
               );
               writeFileSync(
                 join(blankToVariable ? canonicalSparqlBlankToVar : canonicalSparqlBase, `${name}.sparql`),

--- a/engines/algebra-sparql-1-1/test/generateJson.test.ts
+++ b/engines/algebra-sparql-1-1/test/generateJson.test.ts
@@ -8,6 +8,7 @@ import { sparqlQueries, getStaticFilePath } from '@traqula/test-utils';
 import { describe, it } from 'vitest';
 import { toAlgebra, toAst } from '../lib/index.js';
 import { suites } from './algebra.test.js';
+import { allBaseTokens } from '../../../packages/rules-sparql-1-1/lib/lexer/lexer.js';
 
 // WARNING: use this script with caution!
 // After running this script, manual inspection of the output is needed to make sure that conversion happened correctly.

--- a/packages/algebra-transformations-1-1/lib/toAlgebra/aggregate.ts
+++ b/packages/algebra-transformations-1-1/lib/toAlgebra/aggregate.ts
@@ -160,7 +160,7 @@ export const translateAggregates: AlgebraIndir<'translateAggregates', Algebra.Op
     // Slicing needs to happen after construct/describe
     // 18.2.5.5
     const limitOffset = query.solutionModifiers.limitOffset;
-    if ((limitOffset?.limit || limitOffset?.limit === 0) ?? limitOffset?.offset) {
+    if (limitOffset?.limit ?? (limitOffset?.limit === 0 || limitOffset?.offset)) {
       res = AF.createSlice(res, limitOffset.offset ?? 0, limitOffset.limit);
     }
 

--- a/packages/algebra-transformations-1-1/lib/toAlgebra/aggregate.ts
+++ b/packages/algebra-transformations-1-1/lib/toAlgebra/aggregate.ts
@@ -160,7 +160,7 @@ export const translateAggregates: AlgebraIndir<'translateAggregates', Algebra.Op
     // Slicing needs to happen after construct/describe
     // 18.2.5.5
     const limitOffset = query.solutionModifiers.limitOffset;
-    if (limitOffset?.limit ?? (limitOffset?.limit === 0 || limitOffset?.offset)) {
+    if (limitOffset?.limit !== undefined || limitOffset?.offset) {
       res = AF.createSlice(res, limitOffset.offset ?? 0, limitOffset.limit);
     }
 

--- a/packages/algebra-transformations-1-1/lib/toAlgebra/aggregate.ts
+++ b/packages/algebra-transformations-1-1/lib/toAlgebra/aggregate.ts
@@ -160,7 +160,7 @@ export const translateAggregates: AlgebraIndir<'translateAggregates', Algebra.Op
     // Slicing needs to happen after construct/describe
     // 18.2.5.5
     const limitOffset = query.solutionModifiers.limitOffset;
-    if (limitOffset?.limit ?? limitOffset?.offset) {
+    if ((limitOffset?.limit || limitOffset?.limit === 0) ?? limitOffset?.offset) {
       res = AF.createSlice(res, limitOffset.offset ?? 0, limitOffset.limit);
     }
 

--- a/packages/rules-sparql-1-1/lib/grammar/solutionModifier.ts
+++ b/packages/rules-sparql-1-1/lib/grammar/solutionModifier.ts
@@ -263,7 +263,7 @@ export const limitOffsetClauses: SparqlRule<'limitOffsetClauses', SolutionModifi
   gImpl: ({ PRINT_WORDS, NEW_LINE }) => (ast, { astFactory: F }) => {
     F.printFilter(ast, () => {
       NEW_LINE();
-      if (ast.limit) {
+      if (ast.limit !== undefined) {
         PRINT_WORDS('LIMIT', String(ast.limit));
       }
       if (ast.offset) {

--- a/packages/test-utils/statics/algebra/README.md
+++ b/packages/test-utils/statics/algebra/README.md
@@ -1,0 +1,73 @@
+# Algebra test fixtures
+
+This directory holds the static fixtures used by the algebra-conversion tests in
+`engines/algebra-sparql-1-1` and `engines/algebra-sparql-1-2`.
+
+Every test case is **one SPARQL query**, represented **five times**. All five representations live at the *same relative path*, which is how the
+test generators pair them up.
+
+```
+statics/algebra/
+├── sparql/                        <suite>/.../NN.sparql          the input query
+├── algebra/                       <suite>/.../NN.json             expected algebra (blankToVariable: false)
+├── algebra-blank-to-var/          <suite>/.../NN.json             expected algebra (blankToVariable: true)
+└── canonical-sparql/
+    ├── base/                      <suite>/.../NN.sparql            algebra → AST → generator round-trip (blankToVariable: false)
+    └── blank-to-var/              <suite>/.../NN.sparql            same round-trip (blankToVariable: true)
+```
+
+`<suite>` is one of the `AlgebraTestSuite` values: `dawg-syntax`, `sparql-1.1`,
+`sparql11-query`, `sparql12`.
+
+`sparql/` additionally has `sparql-1.1-negative`
+and `sparql-1.2-negative` folders for queries that are expected to *fail*
+algebra translation (see `sparqlAlgebraNegativeTests`). Those only need a
+`.sparql` file, no counterparts elsewhere.
+
+## What each folder is for
+
+- **`sparql/`**: the SPARQL query text. This is the only file you actually
+  have to hand-write. Everything else can be generated from it.
+- **`algebra/`**: the SPARQL algebra tree the query should translate to, as
+  JSON, with blank nodes preserved as blank nodes.
+- **`algebra-blank-to-var/`**: the same algebra tree, but produced with the
+  `blankToVariable: true` option (blank nodes rewritten to variables). This
+  matters for constructs where blank nodes and their variable-rewritten form
+  differ.
+- **`canonical-sparql/base/`**, **`canonical-sparql/blank-to-var/`**: the
+  algebra tree converted *back* to an AST and re-generated as SPARQL text. This
+  isn't necessarily identical to the original query (whitespace, operator
+  order, and implicit defaults get normalized), but it should be an equivalent
+  query. Comparing this "canonical" form is how the AST↔algebra round-trip
+  gets tested independently of the algebra JSON.
+
+## Adding a new test case
+
+1. **Write the SPARQL query.**
+
+    Drop a `.sparql` file under `sparql/<suite>/<...>/<name>.sparql`.
+
+    *Skip step 2-3 if you added a negative test.*
+
+2. **Generate the other four files automatically.**
+
+    Use the generator scripts:
+
+    - `engines/algebra-sparql-1-1/test/generateJson.test.ts` for
+    `dawg-syntax`, `sparql-1.1`, `sparql11-query`.
+    - `engines/algebra-sparql-1-2/test/generateJson.test.ts` for `sparql12`.
+
+    Change `describe.skip(...)` to `describe(...)` in the script.
+
+    Run the script with vitest, e.g. from the repo root:
+    ```
+    yarn vitest run engines/algebra-sparql-1-<X>/test/generateJson.test.ts
+    ```
+    (Change `<X>` to the correct version)
+
+    Change `describe(...)` back to `describe.skip(...)`.
+
+3. **Run all tests** to confirm the new fixture passes:
+   ```
+   yarn test
+   ```

--- a/packages/test-utils/statics/algebra/algebra-blank-to-var/dawg-syntax/limit-offset/05.json
+++ b/packages/test-utils/statics/algebra/algebra-blank-to-var/dawg-syntax/limit-offset/05.json
@@ -1,0 +1,55 @@
+{
+  "type": "project",
+  "input": {
+    "type": "orderby",
+    "input": {
+      "type": "bgp",
+      "patterns": [
+        {
+          "type": "pattern",
+          "termType": "Quad",
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "Variable",
+            "value": "p"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "o"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
+          }
+        }
+      ]
+    },
+    "expressions": [
+      {
+        "type": "expression",
+        "subType": "term",
+        "term": {
+          "termType": "Variable",
+          "value": "o"
+        }
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "o"
+    },
+    {
+      "termType": "Variable",
+      "value": "p"
+    },
+    {
+      "termType": "Variable",
+      "value": "s"
+    }
+  ]
+}

--- a/packages/test-utils/statics/algebra/algebra-blank-to-var/dawg-syntax/limit-offset/05.json
+++ b/packages/test-utils/statics/algebra/algebra-blank-to-var/dawg-syntax/limit-offset/05.json
@@ -1,55 +1,60 @@
 {
-  "type": "project",
+  "type": "slice",
   "input": {
-    "type": "orderby",
+    "type": "project",
     "input": {
-      "type": "bgp",
-      "patterns": [
+      "type": "orderby",
+      "input": {
+        "type": "bgp",
+        "patterns": [
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "s"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        ]
+      },
+      "expressions": [
         {
-          "type": "pattern",
-          "termType": "Quad",
-          "subject": {
-            "termType": "Variable",
-            "value": "s"
-          },
-          "predicate": {
-            "termType": "Variable",
-            "value": "p"
-          },
-          "object": {
+          "type": "expression",
+          "subType": "term",
+          "term": {
             "termType": "Variable",
             "value": "o"
-          },
-          "graph": {
-            "termType": "DefaultGraph",
-            "value": ""
           }
         }
       ]
     },
-    "expressions": [
+    "variables": [
       {
-        "type": "expression",
-        "subType": "term",
-        "term": {
-          "termType": "Variable",
-          "value": "o"
-        }
+        "termType": "Variable",
+        "value": "o"
+      },
+      {
+        "termType": "Variable",
+        "value": "p"
+      },
+      {
+        "termType": "Variable",
+        "value": "s"
       }
     ]
   },
-  "variables": [
-    {
-      "termType": "Variable",
-      "value": "o"
-    },
-    {
-      "termType": "Variable",
-      "value": "p"
-    },
-    {
-      "termType": "Variable",
-      "value": "s"
-    }
-  ]
+  "start": 0,
+  "length": 0
 }

--- a/packages/test-utils/statics/algebra/algebra/dawg-syntax/limit-offset/05.json
+++ b/packages/test-utils/statics/algebra/algebra/dawg-syntax/limit-offset/05.json
@@ -1,0 +1,55 @@
+{
+  "type": "project",
+  "input": {
+    "type": "orderby",
+    "input": {
+      "type": "bgp",
+      "patterns": [
+        {
+          "type": "pattern",
+          "termType": "Quad",
+          "subject": {
+            "termType": "Variable",
+            "value": "s"
+          },
+          "predicate": {
+            "termType": "Variable",
+            "value": "p"
+          },
+          "object": {
+            "termType": "Variable",
+            "value": "o"
+          },
+          "graph": {
+            "termType": "DefaultGraph",
+            "value": ""
+          }
+        }
+      ]
+    },
+    "expressions": [
+      {
+        "type": "expression",
+        "subType": "term",
+        "term": {
+          "termType": "Variable",
+          "value": "o"
+        }
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "o"
+    },
+    {
+      "termType": "Variable",
+      "value": "p"
+    },
+    {
+      "termType": "Variable",
+      "value": "s"
+    }
+  ]
+}

--- a/packages/test-utils/statics/algebra/algebra/dawg-syntax/limit-offset/05.json
+++ b/packages/test-utils/statics/algebra/algebra/dawg-syntax/limit-offset/05.json
@@ -1,55 +1,60 @@
 {
-  "type": "project",
+  "type": "slice",
   "input": {
-    "type": "orderby",
+    "type": "project",
     "input": {
-      "type": "bgp",
-      "patterns": [
+      "type": "orderby",
+      "input": {
+        "type": "bgp",
+        "patterns": [
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "s"
+            },
+            "predicate": {
+              "termType": "Variable",
+              "value": "p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "o"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        ]
+      },
+      "expressions": [
         {
-          "type": "pattern",
-          "termType": "Quad",
-          "subject": {
-            "termType": "Variable",
-            "value": "s"
-          },
-          "predicate": {
-            "termType": "Variable",
-            "value": "p"
-          },
-          "object": {
+          "type": "expression",
+          "subType": "term",
+          "term": {
             "termType": "Variable",
             "value": "o"
-          },
-          "graph": {
-            "termType": "DefaultGraph",
-            "value": ""
           }
         }
       ]
     },
-    "expressions": [
+    "variables": [
       {
-        "type": "expression",
-        "subType": "term",
-        "term": {
-          "termType": "Variable",
-          "value": "o"
-        }
+        "termType": "Variable",
+        "value": "o"
+      },
+      {
+        "termType": "Variable",
+        "value": "p"
+      },
+      {
+        "termType": "Variable",
+        "value": "s"
       }
     ]
   },
-  "variables": [
-    {
-      "termType": "Variable",
-      "value": "o"
-    },
-    {
-      "termType": "Variable",
-      "value": "p"
-    },
-    {
-      "termType": "Variable",
-      "value": "s"
-    }
-  ]
+  "start": 0,
+  "length": 0
 }

--- a/packages/test-utils/statics/algebra/canonical-sparql/base/dawg-syntax/limit-offset/05.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/base/dawg-syntax/limit-offset/05.sparql
@@ -1,0 +1,4 @@
+SELECT ?o ?p ?s WHERE {
+  ?s ?p ?o .
+}
+ORDER BY ASC ( ?o )

--- a/packages/test-utils/statics/algebra/canonical-sparql/base/dawg-syntax/limit-offset/05.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/base/dawg-syntax/limit-offset/05.sparql
@@ -2,3 +2,4 @@ SELECT ?o ?p ?s WHERE {
   ?s ?p ?o .
 }
 ORDER BY ASC ( ?o )
+LIMIT 0

--- a/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/dawg-syntax/limit-offset/05.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/dawg-syntax/limit-offset/05.sparql
@@ -1,0 +1,4 @@
+SELECT ?o ?p ?s WHERE {
+  ?s ?p ?o .
+}
+ORDER BY ASC ( ?o )

--- a/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/dawg-syntax/limit-offset/05.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/dawg-syntax/limit-offset/05.sparql
@@ -2,3 +2,4 @@ SELECT ?o ?p ?s WHERE {
   ?s ?p ?o .
 }
 ORDER BY ASC ( ?o )
+LIMIT 0

--- a/packages/test-utils/statics/algebra/sparql/dawg-syntax/limit-offset/05.sparql
+++ b/packages/test-utils/statics/algebra/sparql/dawg-syntax/limit-offset/05.sparql
@@ -1,0 +1,5 @@
+PREFIX : <http://example.org/ns#>
+SELECT *
+{ ?s ?p ?o }
+ORDER BY ?o
+LIMIT 0


### PR DESCRIPTION
`LIMIT 0` was not transformed to algebra because 0 would make the condition be falsy.

Also added a packages/test-utils/statics/algebra/README.md that explains how you're supposed to add new tests.

This fixes part of https://github.com/comunica/comunica/issues/1736.