### PR TITLE
Add validation for BlankNode scoping (grammar rule 8) using checkBlankNodeBGPScope

### DIFF
--- a/engines/parser-sparql-1-1/package.json
+++ b/engines/parser-sparql-1-1/package.json
@@ -39,7 +39,7 @@
     "build": "yarn build:ts && yarn build:cjs",
     "build:ts": "node \"../../node_modules/typescript/bin/tsc\" -b",
     "build:cjs": "node \"../../node_modules/typescript/bin/tsc\" -b tsconfig.cjs.json",
-    "spec:base-1-0": "rdf-test-suite dist/cjs/spec/parser.js https://w3c.github.io/rdf-tests/sparql/sparql10/manifest.ttl -c ../../.rdf-test-suite-cache/ --skip \"(syn-bad-GRAPH-breaks-BGP|syn-bad-UNION-breaks-BGP|syn-bad-OPT-breaks-BGP|syn-bad-38|syn-bad-37|syn-bad-36|syn-bad-35|syn-bad-34|blabel-cross-union-bad|blabel-cross-optional-bad|blabel-cross-graph-bad)\"",
+    "spec:base-1-0": "rdf-test-suite dist/cjs/spec/parser.js https://w3c.github.io/rdf-tests/sparql/sparql10/manifest.ttl -c ../../.rdf-test-suite-cache/",
     "spec:base-1-1": "rdf-test-suite dist/cjs/spec/parser.js http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl -c ../../.rdf-test-suite-cache/",
     "spec:query": "yarn spec:base-1-1 -- -s http://www.w3.org/TR/sparql11-query/",
     "spec:update": "yarn spec:base-1-1 -- -s http://www.w3.org/TR/sparql11-update/",

--- a/packages/rules-sparql-1-1/lib/grammar/whereClause.ts
+++ b/packages/rules-sparql-1-1/lib/grammar/whereClause.ts
@@ -22,7 +22,7 @@ import type {
   TermVariable,
   ValuePatternRow,
 } from '../Sparql11types.js';
-import { checkNote13 } from '../validation/validators.js';
+import { checkBlankNodeBGPScope, checkNote13 } from '../validation/validators.js';
 import { builtInCall } from './builtIn.js';
 import { argList, brackettedExpression, expression } from './expression.js';
 import { var_, varOrIri, varOrTerm } from './general.js';
@@ -58,6 +58,8 @@ export const groupGraphPattern: SparqlRule<'groupGraphPattern', PatternGroup> = 
       { ALT: () => SUBRULE(groupGraphPatternSub) },
     ]);
     const close = CONSUME(l.symbols.RCurly);
+
+    ACTION(() => !C.skipValidation && checkBlankNodeBGPScope(patterns));
 
     return ACTION(() => C.astFactory.patternGroup(patterns, C.astFactory.sourceLocation(open, close)));
   },

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -4,6 +4,7 @@ import type {
   Expression,
   ExpressionAggregate,
   Pattern,
+  PatternBgp,
   QuerySelect,
   TermVariable,
   SolutionModifierGroupBind,
@@ -243,4 +244,71 @@ export function updateNoReuseBlankNodeLabels(updateQuery: Update): void {
       }
     }
   }
+}
+
+/**
+ * https://www.w3.org/TR/sparql11-query/#QSynBlankNodes
+ * NOTE 11: the scope of a blank node label is limited to the basic graph pattern (BGP) in which
+ * it is used. It is a syntax error to reuse a blank node label in two different basic graph
+ * patterns within the same query.
+ *
+ * A BGP is broken - and a new one started - by constructs that introduce a nested graph pattern:
+ * a nested group `{ }`, `OPTIONAL`, `UNION`, `GRAPH`, `MINUS`, and `SERVICE`, even when they
+ * appear "flat" alongside other triples in the same enclosing `{ }`. `FILTER`, `BIND`, and
+ * `VALUES` do NOT break a BGP - they are constraints/modifiers on the existing pattern rather
+ * than graph patterns of their own, so triples separated only by these remain part of the same
+ * BGP even though the grammar represents them as separate PatternBgp AST nodes.
+ * Subqueries introduce a fresh scope of their own: they are not descended into here, since their
+ * own WHERE clause is validated independently when it is parsed.
+ */
+export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
+  // Maps a blank node label to the scope (an opaque token, unique per BGP) it was first seen in.
+  const labelOwner = new Map<string, object>();
+
+  function collectBlankNodeLabels(bgp: PatternBgp): Set<string> {
+    const labels = new Set<string>();
+    transformer.visitNodeSpecific(bgp, {}, { term: { blankNode: { visitor: (blankNode) => {
+      labels.add(blankNode.label);
+    } }}});
+    return labels;
+  }
+
+  function visitPatternList(list: Pattern[]): void {
+    // All PatternBgp nodes encountered until the next BGP-breaking construct belong to the
+    // same logical BGP, even if FILTER/BIND/VALUES split them into separate AST nodes.
+    let scope: object = {};
+
+    for (const pattern of list) {
+      if (F.isPatternBgp(pattern)) {
+        for (const label of collectBlankNodeLabels(pattern)) {
+          const owner = labelOwner.get(label);
+          if (owner !== undefined && owner !== scope) {
+            throw new Error(
+              `Detected reuse of blank node across two different basic graph patterns (_:${
+                label.replace(/^[eg]_/u, '')})`,
+            );
+          }
+          labelOwner.set(label, scope);
+        }
+      } else if (
+        F.isPatternGroup(pattern) ||
+        F.isPatternOptional(pattern) ||
+        F.isPatternMinus(pattern) ||
+        F.isPatternGraph(pattern) ||
+        F.isPatternService(pattern)
+      ) {
+        visitPatternList(pattern.patterns);
+        scope = {};
+      } else if (F.isPatternUnion(pattern)) {
+        for (const group of pattern.patterns) {
+          visitPatternList(group.patterns);
+        }
+        scope = {};
+      }
+      // PatternFilter, PatternBind, PatternValues, and SubSelect (its own fresh scope) don't
+      // affect or break the current BGP scope.
+    }
+  }
+
+  visitPatternList(patterns);
 }

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -307,6 +307,17 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
         service: boundaryHandler,
         union: boundaryHandler,
       },
+      expression: {
+        patternOperation: {
+          preVisitor: () => {
+            scopeStack.push({});
+            return {};
+          },
+          visitor: () => {
+            scopeStack.pop();
+          },
+        },
+      },
     },
   );
 }

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -274,6 +274,7 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
     },
     visitor: () => {
       scopeStack.pop();
+      // Within a list of patterns, seing this pattern breaks the scope of the list of patterns. BIND and FILTER do not break he scope since when transforming to algebra, they are collected separetly: https://www.w3.org/TR/sparql12-query/#sparqlCollectFilters
       scopeStack[scopeStack.length - 1] = {};
     },
   };

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -253,6 +253,9 @@ export function updateNoReuseBlankNodeLabels(updateQuery: Update): void {
 export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
   const labelOwner = new Map<string, object>();
 
+  const scopeStack: object[] = [{}];
+  const currentScope = (): object => scopeStack.at(-1)!;
+
   function collectBlankNodeLabels(bgp: PatternBgp): Set<string> {
     const labels = new Set<string>();
     transformer.visitNodeSpecific(bgp, {}, { term: { blankNode: { visitor: (blankNode) => {
@@ -261,38 +264,49 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
     return labels;
   }
 
-  function visitPatternList(list: Pattern[]): void {
-    let scope: object = {};
+  const boundaryHandler = {
+    preVisitor: () => {
+      scopeStack.push({});
+      return {};
+    },
+    visitor: () => {
+      scopeStack.pop();
+      scopeStack[scopeStack.length - 1] = {};
+    },
+  };
 
-    for (const pattern of list) {
-      if (F.isPatternBgp(pattern)) {
-        for (const label of collectBlankNodeLabels(pattern)) {
-          const owner = labelOwner.get(label);
-          if (owner !== undefined && owner !== scope) {
-            throw new Error(
-              `Detected reuse of blank node across two different basic graph patterns (_:${
-                label.replace(/^[eg]_/u, '')})`,
-            );
-          }
-          labelOwner.set(label, scope);
-        }
-      } else if (
-        F.isPatternGroup(pattern) ||
-        F.isPatternOptional(pattern) ||
-        F.isPatternMinus(pattern) ||
-        F.isPatternGraph(pattern) ||
-        F.isPatternService(pattern)
-      ) {
-        visitPatternList(pattern.patterns);
-        scope = {};
-      } else if (F.isPatternUnion(pattern)) {
-        for (const group of pattern.patterns) {
-          visitPatternList(group.patterns);
-        }
-        scope = {};
-      }
-    }
-  }
-
-  visitPatternList(patterns);
+  transformer.visitNodeSpecific(
+    patterns,
+    {
+      query: {
+        preVisitor: () => ({ continue: false }),
+      },
+    },
+    {
+      pattern: {
+        bgp: {
+          preVisitor: (bgp) => {
+            const scope = currentScope();
+            for (const label of collectBlankNodeLabels(bgp)) {
+              const owner = labelOwner.get(label);
+              if (owner !== undefined && owner !== scope) {
+                throw new Error(
+                  `Detected reuse of blank node across two different basic graph patterns (_:${
+                    label.replace(/^[eg]_/u, '')})`,
+                );
+              }
+              labelOwner.set(label, scope);
+            }
+            return { continue: false };
+          },
+        },
+        group: boundaryHandler,
+        optional: boundaryHandler,
+        minus: boundaryHandler,
+        graph: boundaryHandler,
+        service: boundaryHandler,
+        union: boundaryHandler,
+      },
+    },
+  );
 }

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -287,6 +287,7 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
       query: {
         preVisitor: () => ({ continue: false }),
       },
+      pattern: newBlankNodeScopeHandler,
     },
     {
       pattern: {
@@ -305,20 +306,12 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
             }
             return { continue: false };
           },
+          visitor: () => {},
         },
-        // All other patterns introduce a new scope
-        group: newBlankNodeScopeHandler,
-        optional: newBlankNodeScopeHandler,
-        minus: newBlankNodeScopeHandler,
-        graph: newBlankNodeScopeHandler,
-        service: newBlankNodeScopeHandler,
-        union: newBlankNodeScopeHandler,
-      },
-      expression: {
         // FILTER (not) EXISTS introduces a new scope.
         // Unlike newBlankScopeHandler, we only pop on exit, we don't reset the parent scope;
         // labels can still be reused after a FILTER or (not) EXISTS.
-        patternOperation: {
+        filter: {
           preVisitor: () => {
             scopeStack.push({});
             return {};

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -274,7 +274,9 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
     },
     visitor: () => {
       scopeStack.pop();
-      // Within a list of patterns, seing this pattern breaks the scope of the list of patterns. BIND and FILTER do not break he scope since when transforming to algebra, they are collected separetly: https://www.w3.org/TR/sparql12-query/#sparqlCollectFilters
+      // Within a list of patterns, seeing this pattern breaks the scope of the list of patterns.
+      // BIND and FILTER do not break the scope since when transforming to algebra, they are collected separately:
+      // https://www.w3.org/TR/sparql12-query/#sparqlCollectFilters
       scopeStack[scopeStack.length - 1] = {};
     },
   };

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -253,6 +253,7 @@ export function updateNoReuseBlankNodeLabels(updateQuery: Update): void {
 export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
   const labelOwner = new Map<string, object>();
 
+  // Each entry is a unique object used only as an identity marker for "the current scope"
   const scopeStack: object[] = [{}];
   const currentScope = (): object => scopeStack.at(-1)!;
 
@@ -264,7 +265,9 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
     return labels;
   }
 
-  const boundaryHandler = {
+  // Introduces a new blank node scope on entry.
+  // Pops the introduced scope and resets the parent scope on exit.
+  const newBlankNodeScopeHandler = {
     preVisitor: () => {
       scopeStack.push({});
       return {};
@@ -300,14 +303,18 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
             return { continue: false };
           },
         },
-        group: boundaryHandler,
-        optional: boundaryHandler,
-        minus: boundaryHandler,
-        graph: boundaryHandler,
-        service: boundaryHandler,
-        union: boundaryHandler,
+        // All other patterns introduce a new scope
+        group: newBlankNodeScopeHandler,
+        optional: newBlankNodeScopeHandler,
+        minus: newBlankNodeScopeHandler,
+        graph: newBlankNodeScopeHandler,
+        service: newBlankNodeScopeHandler,
+        union: newBlankNodeScopeHandler,
       },
       expression: {
+        // FILTER (not) EXISTS introduces a new scope.
+        // Unlike newBlankScopeHandler, we only pop on exit, we don't reset the parent scope;
+        // labels can still be reused after a FILTER or (not) EXISTS.
         patternOperation: {
           preVisitor: () => {
             scopeStack.push({});

--- a/packages/rules-sparql-1-1/lib/validation/validators.ts
+++ b/packages/rules-sparql-1-1/lib/validation/validators.ts
@@ -247,22 +247,10 @@ export function updateNoReuseBlankNodeLabels(updateQuery: Update): void {
 }
 
 /**
- * https://www.w3.org/TR/sparql11-query/#QSynBlankNodes
- * NOTE 11: the scope of a blank node label is limited to the basic graph pattern (BGP) in which
- * it is used. It is a syntax error to reuse a blank node label in two different basic graph
- * patterns within the same query.
- *
- * A BGP is broken - and a new one started - by constructs that introduce a nested graph pattern:
- * a nested group `{ }`, `OPTIONAL`, `UNION`, `GRAPH`, `MINUS`, and `SERVICE`, even when they
- * appear "flat" alongside other triples in the same enclosing `{ }`. `FILTER`, `BIND`, and
- * `VALUES` do NOT break a BGP - they are constraints/modifiers on the existing pattern rather
- * than graph patterns of their own, so triples separated only by these remain part of the same
- * BGP even though the grammar represents them as separate PatternBgp AST nodes.
- * Subqueries introduce a fresh scope of their own: they are not descended into here, since their
- * own WHERE clause is validated independently when it is parsed.
+ * https://www.w3.org/TR/sparql11-query/#bgpBNodeLabels
+ * > A label can be used in only a single basic graph pattern in any query.
  */
 export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
-  // Maps a blank node label to the scope (an opaque token, unique per BGP) it was first seen in.
   const labelOwner = new Map<string, object>();
 
   function collectBlankNodeLabels(bgp: PatternBgp): Set<string> {
@@ -274,8 +262,6 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
   }
 
   function visitPatternList(list: Pattern[]): void {
-    // All PatternBgp nodes encountered until the next BGP-breaking construct belong to the
-    // same logical BGP, even if FILTER/BIND/VALUES split them into separate AST nodes.
     let scope: object = {};
 
     for (const pattern of list) {
@@ -305,8 +291,6 @@ export function checkBlankNodeBGPScope(patterns: Pattern[]): void {
         }
         scope = {};
       }
-      // PatternFilter, PatternBind, PatternValues, and SubSelect (its own fresh scope) don't
-      // affect or break the current BGP scope.
     }
   }
 

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -263,7 +263,7 @@ describe('checkBlankNodeBGPScope', () => {
       .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
   });
 
-  it('allows a blank node reused across triples split by a BIND', ({ expect }) => {
+  it('throws when a blank node is reused across triples split by a BIND', ({ expect }) => {
     const bind = {
       type: 'pattern',
       subType: 'bind',

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -306,8 +306,6 @@ describe('checkBlankNodeBGPScope', () => {
   });
 
   it('still throws when a FILTER is followed by a genuinely new BGP-breaking construct', ({ expect }) => {
-    // `_:a ?p ?v . FILTER(true) . OPTIONAL { _:a ?q 1 }` - FILTER doesn't break the BGP,
-    // but the subsequent OPTIONAL still does.
     const filter = F.patternFilter(F.termLiteral(noLoc, 'true'), noLoc);
     const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
     const optional = F.patternOptional([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -271,7 +271,7 @@ describe('checkBlankNodeBGPScope', () => {
     expect(() => checkBlankNodeBGPScope([ outerBgp, <any> subquery ])).not.toThrow();
   });
 
-  it('ignores non-BGP-bearing patterns such as FILTER and BIND', ({ expect }) => {
+  it('ignores non-BGP-bearing patterns such as simple FILTERs and BINDs', ({ expect }) => {
     const filter = F.patternFilter(F.termLiteral(noLoc, 'true'), noLoc);
     const bind = {
       type: 'pattern',
@@ -314,6 +314,30 @@ describe('checkBlankNodeBGPScope', () => {
     const optional = F.patternOptional([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);
     expect(() => checkBlankNodeBGPScope([ bgp1, <any> filter, optional ]))
       .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('throws when a blank node is reused inside a FILTER (EXISTS) block', ({ expect }) => {
+    const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const existsFilter = F.patternFilter(<any> {
+      type: 'expression',
+      subType: 'patternOperation',
+      operator: 'exists',
+      args: F.patternGroup([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc),
+    }, noLoc);
+    expect(() => checkBlankNodeBGPScope([ outerBgp, <any> existsFilter ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('allows blank node reuse across outer BGPs split by FILTER (EXISTS)', ({ expect }) => {
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const existsFilter = F.patternFilter(<any> {
+      type: 'expression',
+      subType: 'patternOperation',
+      operator: 'exists',
+      args: F.patternGroup([ F.patternBgp([ bnodeTriple('b') ], noLoc) ], noLoc),
+    }, noLoc);
+    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, <any> existsFilter, bgp2 ])).not.toThrow();
   });
 });
 

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -276,7 +276,7 @@ describe('checkBlankNodeBGPScope', () => {
       .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
   });
 
-  it('allows a blank node reused across triples split by a VALUES clause', ({ expect }) => {
+  it('throws when a blank node is reused across reused across triples split by a VALUES clause', ({ expect }) => {
     const values = F.patternValues([ F.termVariable('x', noLoc) ], [{ x: undefined }], noLoc);
     const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
     const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -1,4 +1,7 @@
 import { describe, it } from 'vitest';
+import type {
+  TripleNesting,
+} from '../lib/index.js';
 import {
   AstFactory,
   checkBlankNodeBGPScope,
@@ -188,7 +191,7 @@ describe('updateNoReuseBlankNodeLabels', () => {
 });
 
 describe('checkBlankNodeBGPScope', () => {
-  function bnodeTriple(label: string): any {
+  function bnodeTriple(label: string): TripleNesting {
     const blank = F.termBlank(label, noLoc);
     return F.triple(blank, F.termVariable('p', noLoc), F.termVariable('v', noLoc), noLoc);
   }

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -263,6 +263,27 @@ describe('checkBlankNodeBGPScope', () => {
       .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
   });
 
+  it('allows a blank node reused across triples split by a BIND', ({ expect }) => {
+    const bind = {
+      type: 'pattern',
+      subType: 'bind',
+      variable: F.termVariable('x', noLoc),
+      expression: F.termLiteral(noLoc, '1'),
+    };
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, <Pattern> bind, bgp2 ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('allows a blank node reused across triples split by a VALUES clause', ({ expect }) => {
+    const values = F.patternValues([ F.termVariable('x', noLoc) ], [{ x: undefined }], noLoc);
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, values, bgp2 ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
   // https://www.w3.org/TR/sparql11-query/#subqueries
   // subqueries are evaluated as independent queries first; only projected
   // variables join back into the outer solution, so blank node scope resets
@@ -292,25 +313,6 @@ describe('checkBlankNodeBGPScope', () => {
     const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
     const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
     expect(() => checkBlankNodeBGPScope([ bgp1, <Pattern> filter, bgp2 ])).not.toThrow();
-  });
-
-  it('allows a blank node reused across triples split by a BIND', ({ expect }) => {
-    const bind = {
-      type: 'pattern',
-      subType: 'bind',
-      variable: F.termVariable('x', noLoc),
-      expression: F.termLiteral(noLoc, '1'),
-    };
-    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    expect(() => checkBlankNodeBGPScope([ bgp1, <Pattern> bind, bgp2 ])).not.toThrow();
-  });
-
-  it('allows a blank node reused across triples split by a VALUES clause', ({ expect }) => {
-    const values = F.patternValues([ F.termVariable('x', noLoc) ], [{ x: undefined }], noLoc);
-    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    expect(() => checkBlankNodeBGPScope([ bgp1, values, bgp2 ])).not.toThrow();
   });
 
   it('still throws when a FILTER is followed by a genuinely new BGP-breaking construct', ({ expect }) => {

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'vitest';
 import type {
+  Expression,
+  Pattern,
   TripleNesting,
 } from '../lib/index.js';
 import {
@@ -261,6 +263,9 @@ describe('checkBlankNodeBGPScope', () => {
       .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
   });
 
+  // https://www.w3.org/TR/sparql11-query/#subqueries
+  // subqueries are evaluated as independent queries first; only projected
+  // variables join back into the outer solution, so blank node scope resets
   it('does not descend into subqueries (they have their own fresh scope)', ({ expect }) => {
     const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
     const subquery = {
@@ -268,7 +273,7 @@ describe('checkBlankNodeBGPScope', () => {
       subType: 'select',
       where: F.patternGroup([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc),
     };
-    expect(() => checkBlankNodeBGPScope([ outerBgp, <any> subquery ])).not.toThrow();
+    expect(() => checkBlankNodeBGPScope([ outerBgp, <Pattern> subquery ])).not.toThrow();
   });
 
   it('ignores non-BGP-bearing patterns such as simple FILTERs and BINDs', ({ expect }) => {
@@ -279,14 +284,14 @@ describe('checkBlankNodeBGPScope', () => {
       variable: F.termVariable('x', noLoc),
       expression: F.termLiteral(noLoc, '1'),
     };
-    expect(() => checkBlankNodeBGPScope([ <any> filter, <any> bind ])).not.toThrow();
+    expect(() => checkBlankNodeBGPScope([ <Pattern> filter, <Pattern> bind ])).not.toThrow();
   });
 
   it('allows a blank node reused across triples split by a FILTER', ({ expect }) => {
     const filter = F.patternFilter(F.termLiteral(noLoc, 'true'), noLoc);
     const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
     const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    expect(() => checkBlankNodeBGPScope([ bgp1, <any> filter, bgp2 ])).not.toThrow();
+    expect(() => checkBlankNodeBGPScope([ bgp1, <Pattern> filter, bgp2 ])).not.toThrow();
   });
 
   it('allows a blank node reused across triples split by a BIND', ({ expect }) => {
@@ -298,7 +303,7 @@ describe('checkBlankNodeBGPScope', () => {
     };
     const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
     const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    expect(() => checkBlankNodeBGPScope([ bgp1, <any> bind, bgp2 ])).not.toThrow();
+    expect(() => checkBlankNodeBGPScope([ bgp1, <Pattern> bind, bgp2 ])).not.toThrow();
   });
 
   it('allows a blank node reused across triples split by a VALUES clause', ({ expect }) => {
@@ -312,32 +317,32 @@ describe('checkBlankNodeBGPScope', () => {
     const filter = F.patternFilter(F.termLiteral(noLoc, 'true'), noLoc);
     const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
     const optional = F.patternOptional([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);
-    expect(() => checkBlankNodeBGPScope([ bgp1, <any> filter, optional ]))
+    expect(() => checkBlankNodeBGPScope([ bgp1, <Pattern> filter, optional ]))
       .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
   });
 
   it('throws when a blank node is reused inside a FILTER (EXISTS) block', ({ expect }) => {
     const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    const existsFilter = F.patternFilter(<any> {
+    const existsFilter = F.patternFilter(<Expression> {
       type: 'expression',
       subType: 'patternOperation',
       operator: 'exists',
       args: F.patternGroup([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc),
     }, noLoc);
-    expect(() => checkBlankNodeBGPScope([ outerBgp, <any> existsFilter ]))
+    expect(() => checkBlankNodeBGPScope([ outerBgp, <Pattern> existsFilter ]))
       .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
   });
 
   it('allows blank node reuse across outer BGPs split by FILTER (EXISTS)', ({ expect }) => {
     const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    const existsFilter = F.patternFilter(<any> {
+    const existsFilter = F.patternFilter(<Expression> {
       type: 'expression',
       subType: 'patternOperation',
       operator: 'exists',
       args: F.patternGroup([ F.patternBgp([ bnodeTriple('b') ], noLoc) ], noLoc),
     }, noLoc);
     const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
-    expect(() => checkBlankNodeBGPScope([ bgp1, <any> existsFilter, bgp2 ])).not.toThrow();
+    expect(() => checkBlankNodeBGPScope([ bgp1, <Pattern> existsFilter, bgp2 ])).not.toThrow();
   });
 });
 

--- a/packages/rules-sparql-1-1/test/validators.test.ts
+++ b/packages/rules-sparql-1-1/test/validators.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import {
   AstFactory,
+  checkBlankNodeBGPScope,
   checkNote13,
   findPatternBoundedVars,
   queryProjectionIsGood,
@@ -28,7 +29,7 @@ describe('queryProjectionIsGood', () => {
       where: { type: 'group', patterns: []},
     };
 
-    expect(() => queryProjectionIsGood(<any>query)).toThrowError(/GROUP BY not allowed with wildcard/u);
+    expect(() => queryProjectionIsGood(<any>query)).toThrow(/GROUP BY not allowed with wildcard/u);
   });
 
   it('throws when projecting ungrouped variable', ({ expect }) => {
@@ -45,7 +46,7 @@ describe('queryProjectionIsGood', () => {
       where: { type: 'group', patterns: []},
     };
 
-    expect(() => queryProjectionIsGood(<any>query)).toThrowError(/Variable not allowed in projection/u);
+    expect(() => queryProjectionIsGood(<any>query)).toThrow(/Variable not allowed in projection/u);
   });
 
   it('allows grouped variable in projection', ({ expect }) => {
@@ -88,7 +89,7 @@ describe('checkNote13', () => {
       expression: F.termLiteral(noLoc, 'value'),
     };
 
-    expect(() => checkNote13(<any>[ bgp, bind ])).toThrowError(/Variable used to bind is already bound/u);
+    expect(() => checkNote13(<any>[ bgp, bind ])).toThrow(/Variable used to bind is already bound/u);
   });
 
   it('allows BIND with fresh variable', ({ expect }) => {
@@ -140,7 +141,7 @@ describe('updateNoReuseBlankNodeLabels', () => {
     };
 
     expect(() => updateNoReuseBlankNodeLabels(<any>update))
-      .toThrowError(/Detected reuse blank node across different INSERT DATA clauses/u);
+      .toThrow(/Detected reuse blank node across different INSERT DATA clauses/u);
   });
 
   it('allows different blank node labels in separate INSERT DATA clauses', ({ expect }) => {
@@ -183,6 +184,135 @@ describe('updateNoReuseBlankNodeLabels', () => {
     };
 
     expect(() => updateNoReuseBlankNodeLabels(<any>update)).not.toThrow();
+  });
+});
+
+describe('checkBlankNodeBGPScope', () => {
+  function bnodeTriple(label: string): any {
+    const blank = F.termBlank(label, noLoc);
+    return F.triple(blank, F.termVariable('p', noLoc), F.termVariable('v', noLoc), noLoc);
+  }
+
+  it('allows the same blank node reused within a single BGP', ({ expect }) => {
+    const bgp = F.patternBgp([ bnodeTriple('a'), bnodeTriple('a') ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp ])).not.toThrow();
+  });
+
+  it('allows different blank nodes across different BGPs', ({ expect }) => {
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const bgp2 = F.patternBgp([ bnodeTriple('b') ], noLoc);
+    const group = F.patternGroup([ bgp2 ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, group ])).not.toThrow();
+  });
+
+  it('throws when a blank node is reused across a nested group and its parent BGP', ({ expect }) => {
+    const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const innerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const group = F.patternGroup([ innerBgp ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ outerBgp, group ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('throws when a blank node is reused across UNION branches', ({ expect }) => {
+    const branch1 = F.patternGroup([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);
+    const branch2 = F.patternGroup([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);
+    const union = F.patternUnion([ branch1, branch2 ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ union ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('throws when a blank node is reused across an OPTIONAL block', ({ expect }) => {
+    const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const optional = F.patternOptional([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ outerBgp, optional ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('throws when a blank node is reused across a MINUS block', ({ expect }) => {
+    const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const minus = F.patternMinus([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ outerBgp, minus ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('throws when a blank node is reused across a GRAPH block', ({ expect }) => {
+    const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const graph = F.patternGraph(
+      F.termVariable('g', noLoc),
+      [ F.patternBgp([ bnodeTriple('a') ], noLoc) ],
+      noLoc,
+    );
+    expect(() => checkBlankNodeBGPScope([ outerBgp, graph ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('throws when a blank node is reused across a SERVICE block', ({ expect }) => {
+    const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const service = F.patternService(
+      F.termVariable('g', noLoc),
+      [ F.patternBgp([ bnodeTriple('a') ], noLoc) ],
+      false,
+      noLoc,
+    );
+    expect(() => checkBlankNodeBGPScope([ outerBgp, service ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
+  });
+
+  it('does not descend into subqueries (they have their own fresh scope)', ({ expect }) => {
+    const outerBgp = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const subquery = {
+      type: 'query',
+      subType: 'select',
+      where: F.patternGroup([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc),
+    };
+    expect(() => checkBlankNodeBGPScope([ outerBgp, <any> subquery ])).not.toThrow();
+  });
+
+  it('ignores non-BGP-bearing patterns such as FILTER and BIND', ({ expect }) => {
+    const filter = F.patternFilter(F.termLiteral(noLoc, 'true'), noLoc);
+    const bind = {
+      type: 'pattern',
+      subType: 'bind',
+      variable: F.termVariable('x', noLoc),
+      expression: F.termLiteral(noLoc, '1'),
+    };
+    expect(() => checkBlankNodeBGPScope([ <any> filter, <any> bind ])).not.toThrow();
+  });
+
+  it('allows a blank node reused across triples split by a FILTER', ({ expect }) => {
+    const filter = F.patternFilter(F.termLiteral(noLoc, 'true'), noLoc);
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, <any> filter, bgp2 ])).not.toThrow();
+  });
+
+  it('allows a blank node reused across triples split by a BIND', ({ expect }) => {
+    const bind = {
+      type: 'pattern',
+      subType: 'bind',
+      variable: F.termVariable('x', noLoc),
+      expression: F.termLiteral(noLoc, '1'),
+    };
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, <any> bind, bgp2 ])).not.toThrow();
+  });
+
+  it('allows a blank node reused across triples split by a VALUES clause', ({ expect }) => {
+    const values = F.patternValues([ F.termVariable('x', noLoc) ], [{ x: undefined }], noLoc);
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const bgp2 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, values, bgp2 ])).not.toThrow();
+  });
+
+  it('still throws when a FILTER is followed by a genuinely new BGP-breaking construct', ({ expect }) => {
+    // `_:a ?p ?v . FILTER(true) . OPTIONAL { _:a ?q 1 }` - FILTER doesn't break the BGP,
+    // but the subsequent OPTIONAL still does.
+    const filter = F.patternFilter(F.termLiteral(noLoc, 'true'), noLoc);
+    const bgp1 = F.patternBgp([ bnodeTriple('a') ], noLoc);
+    const optional = F.patternOptional([ F.patternBgp([ bnodeTriple('a') ], noLoc) ], noLoc);
+    expect(() => checkBlankNodeBGPScope([ bgp1, <any> filter, optional ]))
+      .toThrow(/Detected reuse of blank node across two different basic graph patterns \(_:a\)/u);
   });
 });
 
@@ -306,7 +436,7 @@ describe('queryProjectionIsGood - additional cases', () => {
       where: { type: 'group', patterns: []},
     };
     expect(() => queryProjectionIsGood(<any>query))
-      .toThrowError(/Use of ungrouped variable in projection/u);
+      .toThrow(/Use of ungrouped variable in projection/u);
   });
 
   it('exercises getVariablesFromExpression with nested operator', ({ expect }) => {
@@ -349,7 +479,7 @@ describe('queryProjectionIsGood - additional cases', () => {
       },
     };
     expect(() => queryProjectionIsGood(<any>query))
-      .toThrowError(/Target id of 'AS' \(\?x\) already used in subquery/u);
+      .toThrow(/Target id of 'AS' \(\?x\) already used in subquery/u);
   });
 });
 
@@ -366,7 +496,7 @@ describe('checkNote13 - second bounded vars check', () => {
     };
     // Second loop: values adds 'x', then bind sees 'x' already bound -> L214
     expect(() => checkNote13(<any>[ valuesPattern, bind ]))
-      .toThrowError(/Variable used to bind is already bound/u);
+      .toThrow(/Variable used to bind is already bound/u);
   });
 });
 

--- a/packages/test-utils/statics/ast/sparql/sparql-1-1-invalid/bnode-reuse-subquery-union.sparql
+++ b/packages/test-utils/statics/ast/sparql/sparql-1-1-invalid/bnode-reuse-subquery-union.sparql
@@ -1,0 +1,4 @@
+SELECT * {
+   ?x ?y ?z .
+   { SELECT DISTINCT * { { _:b ?a ?b . } UNION { _:b ?c ?d } } }
+}


### PR DESCRIPTION
This added check was needed for the 1.0 spec tests that were skipped, they now all succeed.

The specs for [SPARQL 1.0](https://www.w3.org/TR/rdf-sparql-query/#bgpBNodeLabels) and [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/#bgpBNodeLabels) say: "A label can be used in only a single basic graph pattern in any query."

[SPARQL 2.0](https://www.w3.org/TR/sparql12-query/#bgpBNodeIdentifiers) says the same, but uses "blank node identifier" instead of "blank node label".