### PR TITLE
Prevent filter hoisting into leftJoins when filters are not declared in immediate child group

### DIFF
--- a/packages/algebra-transformations-1-1/lib/toAlgebra/patterns.ts
+++ b/packages/algebra-transformations-1-1/lib/toAlgebra/patterns.ts
@@ -201,7 +201,7 @@ AlgebraIndir<'accumulateGroupGraphPattern', Algebra.Operation, [Algebra.Operatio
     if (F.isPatternOptional(pattern)) {
       // Optional input needs to be interpreted as a group
       const groupAsAlgebra = SUBRULE(translateGraphPattern, F.patternGroup(pattern.patterns, pattern.loc));
-      if (groupAsAlgebra.type === types.FILTER) {
+      if (groupAsAlgebra.type === types.FILTER && pattern.patterns.some(p => F.isPatternFilter(p))) {
         return AF.createLeftJoin(algebraOp, groupAsAlgebra.input, groupAsAlgebra.expression);
       }
       return AF.createLeftJoin(algebraOp, groupAsAlgebra);

--- a/packages/algebra-transformations-1-1/lib/toAlgebra/patterns.ts
+++ b/packages/algebra-transformations-1-1/lib/toAlgebra/patterns.ts
@@ -201,7 +201,8 @@ AlgebraIndir<'accumulateGroupGraphPattern', Algebra.Operation, [Algebra.Operatio
     if (F.isPatternOptional(pattern)) {
       // Optional input needs to be interpreted as a group
       const groupAsAlgebra = SUBRULE(translateGraphPattern, F.patternGroup(pattern.patterns, pattern.loc));
-      // Hoist FILTER if it's an immediate child of the pattern
+      // Only hoist FILTER into LEFT_JOIN if it's a direct child of this OPTIONAL's group (per SPARQL 18.2.2.8):
+      // a nested group's FILTER is scoped to that inner group and hoisting it would change what bindings it sees.
       if (groupAsAlgebra.type === types.FILTER && pattern.patterns.some(p => F.isPatternFilter(p))) {
         return AF.createLeftJoin(algebraOp, groupAsAlgebra.input, groupAsAlgebra.expression);
       }

--- a/packages/algebra-transformations-1-1/lib/toAlgebra/patterns.ts
+++ b/packages/algebra-transformations-1-1/lib/toAlgebra/patterns.ts
@@ -201,6 +201,7 @@ AlgebraIndir<'accumulateGroupGraphPattern', Algebra.Operation, [Algebra.Operatio
     if (F.isPatternOptional(pattern)) {
       // Optional input needs to be interpreted as a group
       const groupAsAlgebra = SUBRULE(translateGraphPattern, F.patternGroup(pattern.patterns, pattern.loc));
+      // Hoist FILTER if it's an immediate child of the pattern
       if (groupAsAlgebra.type === types.FILTER && pattern.patterns.some(p => F.isPatternFilter(p))) {
         return AF.createLeftJoin(algebraOp, groupAsAlgebra.input, groupAsAlgebra.expression);
       }

--- a/packages/test-utils/statics/algebra/algebra-blank-to-var/dawg-syntax/opt-filter/03.json
+++ b/packages/test-utils/statics/algebra/algebra-blank-to-var/dawg-syntax/opt-filter/03.json
@@ -1,0 +1,106 @@
+{
+  "type": "project",
+  "input": {
+    "type": "leftjoin",
+    "input": [
+      {
+        "type": "bgp",
+        "patterns": [
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "x"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://example/p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "v"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        ]
+      },
+      {
+        "type": "filter",
+        "input": {
+          "type": "bgp",
+          "patterns": [
+            {
+              "type": "pattern",
+              "termType": "Quad",
+              "subject": {
+                "termType": "Variable",
+                "value": "y"
+              },
+              "predicate": {
+                "termType": "NamedNode",
+                "value": "http://example/q"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "w"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              }
+            }
+          ]
+        },
+        "expression": {
+          "type": "expression",
+          "subType": "operator",
+          "operator": "=",
+          "args": [
+            {
+              "type": "expression",
+              "subType": "term",
+              "term": {
+                "termType": "Variable",
+                "value": "v"
+              }
+            },
+            {
+              "type": "expression",
+              "subType": "term",
+              "term": {
+                "termType": "Literal",
+                "value": "2",
+                "datatype": {
+                  "termType": "NamedNode",
+                  "value": "http://www.w3.org/2001/XMLSchema#integer"
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "v"
+    },
+    {
+      "termType": "Variable",
+      "value": "w"
+    },
+    {
+      "termType": "Variable",
+      "value": "x"
+    },
+    {
+      "termType": "Variable",
+      "value": "y"
+    }
+  ]
+}

--- a/packages/test-utils/statics/algebra/algebra/dawg-syntax/opt-filter/03.json
+++ b/packages/test-utils/statics/algebra/algebra/dawg-syntax/opt-filter/03.json
@@ -1,0 +1,106 @@
+{
+  "type": "project",
+  "input": {
+    "type": "leftjoin",
+    "input": [
+      {
+        "type": "bgp",
+        "patterns": [
+          {
+            "type": "pattern",
+            "termType": "Quad",
+            "subject": {
+              "termType": "Variable",
+              "value": "x"
+            },
+            "predicate": {
+              "termType": "NamedNode",
+              "value": "http://example/p"
+            },
+            "object": {
+              "termType": "Variable",
+              "value": "v"
+            },
+            "graph": {
+              "termType": "DefaultGraph",
+              "value": ""
+            }
+          }
+        ]
+      },
+      {
+        "type": "filter",
+        "input": {
+          "type": "bgp",
+          "patterns": [
+            {
+              "type": "pattern",
+              "termType": "Quad",
+              "subject": {
+                "termType": "Variable",
+                "value": "y"
+              },
+              "predicate": {
+                "termType": "NamedNode",
+                "value": "http://example/q"
+              },
+              "object": {
+                "termType": "Variable",
+                "value": "w"
+              },
+              "graph": {
+                "termType": "DefaultGraph",
+                "value": ""
+              }
+            }
+          ]
+        },
+        "expression": {
+          "type": "expression",
+          "subType": "operator",
+          "operator": "=",
+          "args": [
+            {
+              "type": "expression",
+              "subType": "term",
+              "term": {
+                "termType": "Variable",
+                "value": "v"
+              }
+            },
+            {
+              "type": "expression",
+              "subType": "term",
+              "term": {
+                "termType": "Literal",
+                "value": "2",
+                "datatype": {
+                  "termType": "NamedNode",
+                  "value": "http://www.w3.org/2001/XMLSchema#integer"
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "variables": [
+    {
+      "termType": "Variable",
+      "value": "v"
+    },
+    {
+      "termType": "Variable",
+      "value": "w"
+    },
+    {
+      "termType": "Variable",
+      "value": "x"
+    },
+    {
+      "termType": "Variable",
+      "value": "y"
+    }
+  ]
+}

--- a/packages/test-utils/statics/algebra/canonical-sparql/base/dawg-syntax/opt-filter/03.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/base/dawg-syntax/opt-filter/03.sparql
@@ -1,0 +1,9 @@
+SELECT ?v ?w ?x ?y WHERE {
+  ?x <http://example/p> ?v .
+  OPTIONAL {
+    {
+      ?y <http://example/q> ?w .
+      FILTER ( ( ?v = "2"^^<http://www.w3.org/2001/XMLSchema#integer> ) )
+    }
+  }
+}

--- a/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/dawg-syntax/opt-filter/03.sparql
+++ b/packages/test-utils/statics/algebra/canonical-sparql/blank-to-var/dawg-syntax/opt-filter/03.sparql
@@ -1,0 +1,9 @@
+SELECT ?v ?w ?x ?y WHERE {
+  ?x <http://example/p> ?v .
+  OPTIONAL {
+    {
+      ?y <http://example/q> ?w .
+      FILTER ( ( ?v = "2"^^<http://www.w3.org/2001/XMLSchema#integer> ) )
+    }
+  }
+}

--- a/packages/test-utils/statics/algebra/sparql/dawg-syntax/opt-filter/03.sparql
+++ b/packages/test-utils/statics/algebra/sparql/dawg-syntax/opt-filter/03.sparql
@@ -1,0 +1,11 @@
+PREFIX : <http://example/>
+
+SELECT * {
+    ?x :p ?v .
+    OPTIONAL {
+        {
+            ?y :q ?w .
+            FILTER(?v=2)
+        }
+    }
+}


### PR DESCRIPTION
This is a bug related to the `dawg-optional-filter-005-not-simplified` failure which is part of https://github.com/comunica/comunica/issues/1736.

This is the query that resulted in the bug:

```SPARQL
PREFIX  dc: <http://purl.org/dc/elements/1.1/>
PREFIX  x: <http://example.org/ns#>
SELECT  ?title ?price
WHERE
    { ?book dc:title ?title . 
      OPTIONAL
        {
          { 
            ?book x:price ?price . 
            FILTER (?title = "TITLE 2") .
          }
        } .
    }
```

I verified with comunica that this change is indeed required in Traqula. But my comunica implementation was a bit brute force, it fixed this test, but it made other tests fail, so I haven't committed this yet to a PR that I can link to.